### PR TITLE
Add task to install boto3

### DIFF
--- a/src/playbook.yml
+++ b/src/playbook.yml
@@ -35,3 +35,15 @@
     - name: Start up Guacamole Docker composition
       docker_compose:
         project_src: /var/guacamole
+
+# boto3 is needed during deployment to fetch SSL certificates
+- hosts: all
+  name: Install boto3
+  become: yes
+  become_method: sudo
+  tasks:
+    - name: Install boto3
+      pip:
+        executable: pip3
+        name:
+          - boto3


### PR DESCRIPTION
boto3 is needed during deployment (cloud-init) to fetch the SSL certificate for the Guacamole server from an S3 bucket.