### PR TITLE
Remove unneeded start-up step

### DIFF
--- a/src/playbook.yml
+++ b/src/playbook.yml
@@ -27,15 +27,6 @@
   roles:
     - guacamole
 
-- hosts: all
-  name: Start up Guacamole Docker composition
-  become: yes
-  become_method: sudo
-  tasks:
-    - name: Start up Guacamole Docker composition
-      docker_compose:
-        project_src: /var/guacamole
-
 # boto3 is needed during deployment to fetch SSL certificates
 - hosts: all
   name: Install boto3


### PR DESCRIPTION
Now that the [Guacamole Docker composition installation](https://github.com/cisagov/ansible-role-guacamole) has been changed so that the composition starts automatically as a systemd service (see https://github.com/cisagov/ansible-role-guacamole/pull/2), we no longer need to start up the composition here in the packer.