### PR TITLE
Bump build version to rebuild AMI

### DIFF
--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -17,7 +17,6 @@
   name: freeipa_client
 - src: https://github.com/cisagov/ansible-role-guacamole
   name: guacamole
-  version: improvement/preload-docker-images
 - src: https://github.com/cisagov/ansible-role-htop
   name: htop
 - src: https://github.com/cisagov/ansible-role-joiner-user

--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -17,6 +17,7 @@
   name: freeipa_client
 - src: https://github.com/cisagov/ansible-role-guacamole
   name: guacamole
+  version: improvement/preload-docker-images
 - src: https://github.com/cisagov/ansible-role-htop
   name: htop
 - src: https://github.com/cisagov/ansible-role-joiner-user

--- a/src/version.txt
+++ b/src/version.txt
@@ -1,1 +1,1 @@
-__version__ = "0.1.3+build.2"
+__version__ = "0.1.3+build.3"

--- a/src/version.txt
+++ b/src/version.txt
@@ -1,1 +1,1 @@
-__version__ = "0.1.3+build.3"
+__version__ = "0.1.3+build.4"


### PR DESCRIPTION
## 🗣 Description ##

This pull request simply bumps the build version, so that the Guacamole AMI can be rebuilt.  This allows us to pick up the changes from cisagov/ansible-role-guacamole#26.

## 💭 Motivation and context ##

cisagov/cool-assessment-terraform currently has a NAT gateway in the operations subnet. This NAT gateway is only used when the Guacamole instance pulls the Docker images used by the Guacamole Docker composition at first start up. By preloading these Docker images in the Guacamole AMI, we remove the need for this NAT gateway resource.

See cisagov/cool-system#158 for more details.

## 🧪 Testing ##

I built a staging AMI with this code and verified in env0 of our staging COOL environment that the Docker images used by the Guacamole Docker composition are now preinstalled.

## ✅ Pre-approval checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
* [x] New staging AMI built.
* [x] New staging AMI deployed and tested.

## ✅ Pre-merge checklist ##

* [x] Revert back to the `develop` branch of [cisagov/ansible-role-guacamole](https://github.com/cisagov/ansible-role-guacamole) once cisagov/ansible-role-guacamole#26 is merged.

## ✅ Post-merge checklist ##

* [x] New production AMI built.
